### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/setup/helpers/netbox_objects.py
+++ b/setup/helpers/netbox_objects.py
@@ -59,14 +59,14 @@ class Netbox:
                         child_key = next(iter(value))
                         child_value = value[child_key]
                         if not hasattr(self.obj, key) or not hasattr(getattr(self.obj, key), child_key) or getattr(getattr(self.obj, key), child_key) != child_value:
-                            print(f"Updating '{key}' from '***' to '{self._sanitize_value(key, value)}'")
                             setattr(self.obj, key, value)
-                            updated = True 
+                            updated = True
+                            print(f"Updated field '{key}' successfully.")
                 else:
                     if getattr(self.obj, key) != value:
-                        print(f"Updating '{key}' from '***' to '{self._sanitize_value(key, value)}'")
                         setattr(self.obj, key, value)
-                        updated = True                
+                        updated = True
+                        print(f"Updated field '{key}' successfully.")
             if updated:
                 self.obj.save()
                 # TODO: error handling here

--- a/setup/helpers/netbox_objects.py
+++ b/setup/helpers/netbox_objects.py
@@ -1,6 +1,15 @@
 import pynetbox
 
 class Netbox:
+
+    def _sanitize_value(self, key, value):
+        # Mask sensitive fields
+        sensitive_keys = {'password', 'token', 'secret'}
+        return '***' if key in sensitive_keys else value
+
+    def _sanitize_payload(self):
+        # Return a sanitized version of the payload
+        return {key: self._sanitize_value(key, value) for key, value in self.payload.items()}
     def __init__(self, url, token, payload) -> None:
         # NetBox API details
         self.netbox_url = url
@@ -44,20 +53,20 @@ class Netbox:
                         child_key = next(iter(value))
                         child_value = value[child_key]
                         if not hasattr(self.obj, key) or not hasattr(getattr(self.obj, key), child_key) or getattr(getattr(self.obj, key), child_key) != child_value:
-                            print(f"Updating '{key}' from '{getattr(self.obj, key)}' to '{value}'")
+                            print(f"Updating '{key}' from '{getattr(self.obj, key)}' to '{self._sanitize_value(key, value)}'")
                             setattr(self.obj, key, value)
                             updated = True 
                 else:
                     if getattr(self.obj, key) != value:
-                        print(f"Updating '{key}' from '{getattr(self.obj, key)}' to '{value}'")
+                        print(f"Updating '{key}' from '{getattr(self.obj, key)}' to '{self._sanitize_value(key, value)}'")
                         setattr(self.obj, key, value)
                         updated = True                
             if updated:
                 self.obj.save()
                 # TODO: error handling here
-                print(f"Object '{self.payload}' updated successfully.")
+                print(f"Object '{self._sanitize_payload()}' updated successfully.")
             else:
-                print(f"No changes detected for '{self.payload}'.")
+                print(f"No changes detected for '{self._sanitize_payload()}'.")
         # If the object doesn't exist then create it
         else:
             if self.hasRequired:


### PR DESCRIPTION
Potential fix for [https://github.com/netboxlabs/netbox-proxmox-automation/security/code-scanning/3](https://github.com/netboxlabs/netbox-proxmox-automation/security/code-scanning/3)

To fix the issue, we need to ensure that sensitive data is not logged. This can be achieved by filtering out sensitive keys (e.g., `password`) from the `payload` dictionary before logging. Instead of logging the full `value`, we can log a sanitized version of the data, such as masking sensitive fields or excluding them entirely. This approach maintains the utility of the logs for debugging while protecting sensitive information.

Specifically:
1. Identify sensitive keys (e.g., `password`) in the `payload` dictionary.
2. Replace their values with a placeholder (e.g., `***`) or exclude them from the log message.
3. Update the `print` statements in the `createOrUpdate` method to use the sanitized data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
