### PR TITLE
Potential fix for code scanning alert no. 6: Log Injection

### DIFF
--- a/netbox-event-driven-automation-flask-app/app.py
+++ b/netbox-event-driven-automation-flask-app/app.py
@@ -90,7 +90,8 @@ class WebhookListener(Resource):
         except:
             webhook_json_data = {}
 
-        logger.info("{}".format(webhook_json_data))
+        sanitized_data = json.dumps(webhook_json_data).replace('\n', '').replace('\r', '')
+        logger.info("User-provided data: {}".format(sanitized_data))
 
         if not webhook_json_data or "model" not in webhook_json_data or "event" not in webhook_json_data:
             return {"result":"invalid input"}, 400


### PR DESCRIPTION
Potential fix for [https://github.com/netboxlabs/netbox-proxmox-automation/security/code-scanning/6](https://github.com/netboxlabs/netbox-proxmox-automation/security/code-scanning/6)

To fix the issue, we need to sanitize the user-provided data (`webhook_json_data`) before logging it. Specifically, we should remove any newline characters (`\n` and `\r\n`) from the data to prevent log injection. Additionally, we should ensure that the logged data is clearly marked as user input to avoid confusion. This can be achieved by converting the data to a sanitized string representation.

The fix involves:
1. Sanitizing `webhook_json_data` by replacing newline characters with empty strings.
2. Logging the sanitized version of the data instead of the raw user input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
