### PR TITLE
Potential fix for code scanning alert no. 5: Log Injection

### DIFF
--- a/netbox-event-driven-automation-flask-app/app.py
+++ b/netbox-event-driven-automation-flask-app/app.py
@@ -76,7 +76,10 @@ class WebhookListener(Resource):
         _session['version_lastrun'] = VERSION
         _session['status']['requests'] += 1
         _session['status']['last_called'] = datetime.now()
-        logger.info(f"{request.full_path}, {request.remote_addr}, Status request with data {request.get_data()}")
+        sanitized_full_path = request.full_path.replace('\r\n', '').replace('\n', '')
+        sanitized_remote_addr = request.remote_addr.replace('\r\n', '').replace('\n', '') if request.remote_addr else 'Unknown'
+        sanitized_data = request.get_data(as_text=True).replace('\r\n', '').replace('\n', '') if request.get_data() else ''
+        logger.info(f"{sanitized_full_path}, {sanitized_remote_addr}, Status request with data {sanitized_data}")
         return jsonify(_session)
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/netboxlabs/netbox-proxmox-automation/security/code-scanning/5](https://github.com/netboxlabs/netbox-proxmox-automation/security/code-scanning/5)

To fix the issue, we need to sanitize the user-provided values before logging them. Specifically:
1. Replace newline characters (`\r\n` and `\n`) in `request.full_path`, `request.remote_addr`, and `request.get_data()` with empty strings to prevent log injection.
2. Ensure that the sanitized values are used in the log message.

The fix involves modifying the log entry on line 79 to sanitize the user-provided values before they are interpolated into the log message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
