### PR TITLE
Potential fix for code scanning alert no. 12: Accepting unknown SSH host keys when using Paramiko

### DIFF
--- a/setup/helpers/netbox_proxmox_cluster.py
+++ b/setup/helpers/netbox_proxmox_cluster.py
@@ -82,8 +82,8 @@ class NetBoxProxmoxCluster(ProxmoxAPICommon):
         # Create an SSH client instance
         client = paramiko.SSHClient()
 
-        # Set policy for handling unknown host keys (AutoAddPolicy for convenience, RejectPolicy for security in production)
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        # Set policy for handling unknown host keys (RejectPolicy for security)
+        client.set_missing_host_key_policy(paramiko.RejectPolicy())
 
         # Connect to the server
         try:


### PR DESCRIPTION
Potential fix for [https://github.com/netboxlabs/netbox-proxmox-automation/security/code-scanning/12](https://github.com/netboxlabs/netbox-proxmox-automation/security/code-scanning/12)

To fix this issue, `paramiko.SSHClient.set_missing_host_key_policy()` should be set to `paramiko.RejectPolicy()` rather than `paramiko.AutoAddPolicy()`. This causes the SSH client to abort if it encounters an unknown host key, which is the correct behaviour for production or security-sensitive contexts. This change should be made on line 86 of setup/helpers/netbox_proxmox_cluster.py in the `__get_proxmox_node_info_cmd` method.

No new methods or libraries are required beyond what is already imported. The only change needed is to set the correct host key policy, which paramiko provides by default. If there is a corner case where legitimately unknown host keys must be handled, a separate secure mechanism should be created, such as manually verifying and adding host keys, rather than using `AutoAddPolicy`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
