### PR TITLE
Potential fix for code scanning alert no. 11: Clear-text logging of sensitive information

### DIFF
--- a/setup/netbox-discover-proxmox-cluster-and-nodes.py
+++ b/setup/netbox-discover-proxmox-cluster-and-nodes.py
@@ -208,7 +208,7 @@ def main():
             if device_interface.name.startswith('vmbr'):
                 continue
 
-            print(f"device: {proxmox_node}, interface: {device_interface} {device_interface.type} {device_interface.mac_address}")
+            print(f"device: {proxmox_node}, interface: {device_interface.name} ({device_interface.type}) [MAC address redacted]")
 
             try:
                 NetBoxDeviceInterfaceMacAddressMapping(nb_url, app_config['netbox_api_config']['api_token'], netbox_device_id, device_interface, nb_pxmx_cluster.discovered_proxmox_nodes_information[proxmox_node]['system']['network_interfaces'][device_interface.name])            


### PR DESCRIPTION
Potential fix for [https://github.com/netboxlabs/netbox-proxmox-automation/security/code-scanning/11](https://github.com/netboxlabs/netbox-proxmox-automation/security/code-scanning/11)

To resolve the issue, avoid logging the full representation of sensitive objects and specifically ensure that sensitive information such as MAC addresses is never logged in clear text. The best approach is to log only non-sensitive identifiers, or simply indicate the presence or operation without including confidential data.

1. **General Fix:**  
   - Avoid printing/displaying the MAC address.  
   - Optionally, if interface details are useful for diagnostics, print only non-sensitive fields (e.g., interface name and maybe type).  
   - If detailed diagnostic is truly required, at most print a redacted version of the MAC (e.g., show only the prefix), making it clear that it's redacted.

2. **Specific file/region/lines to change:**  
   - In `setup/netbox-discover-proxmox-cluster-and-nodes.py`, line 211:  
     Change or remove the `print` statement so that it does not output any sensitive data (especially no MAC addresses).
   - No additional methods or imports are needed if simply removing or replacing the print content.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
