### PR TITLE
Potential fix for code scanning alert no. 13: Information exposure through an exception

### DIFF
--- a/netbox-event-driven-automation-flask-app/helpers/netbox_proxmox.py
+++ b/netbox-event-driven-automation-flask-app/helpers/netbox_proxmox.py
@@ -6,6 +6,7 @@ import time
 import urllib
 
 from proxmoxer import ProxmoxAPI, ResourceException
+import logging
 
 class NetBoxProxmoxHelper:
     def __init__(self, cfg_data, proxmox_node, debug=False):
@@ -696,12 +697,15 @@ class NetBoxProxmoxHelperMigrate(NetBoxProxmoxHelper):
                     else:
                         return 500, {'result': f"Task {proxmox_task_id} is stopped but exit status does not appear to be successful: {task_status['exit_status']}"}
         except ResourceException as e:
-            return 500, {'content': f"Proxmox API error: {e}"}
+            logging.error(f"Proxmox API ResourceException: {e}")
+            return 500, {'content': "Proxmox API error occurred."}
         except requests.exceptions.ConnectionError as e:
-            return 500, {'content': f"Failed to connect to Proxmox API: {e}"}
+            logging.error(f"Proxmox API ConnectionError: {e}")
+            return 500, {'content': "Failed to connect to Proxmox API."}
         except requests.exceptions.HTTPError as e:
             status = e.response.status_code
-            return 500, {'content': f"HTTP {status}: {e.response.text}"}
+            logging.error(f"Proxmox API HTTPError {status}: {e.response.text}")
+            return 500, {'content': f"Proxmox API HTTP error occurred (code {status})."}
 
 
     def migrate_vm(self, proxmox_vmid: int, proxmox_node: str, proxmox_target_node: str):
@@ -714,12 +718,15 @@ class NetBoxProxmoxHelperMigrate(NetBoxProxmoxHelper):
             migrate_vm_task_id = self.proxmox_api.nodes(proxmox_node).qemu(proxmox_vmid).migrate.post(**migrate_vm_data)
             return self.__wait_for_migration_task(proxmox_node, migrate_vm_task_id)
         except ResourceException as e:
-            return 500, {'result': f"Proxmox API error: {e}"}
-        except requests.exceptions.ConnectionError:
-            return 500, {'result': f"Failed to connect to Proxmox API: {e}"}
+            logging.error(f"Proxmox API ResourceException: {e}")
+            return 500, {'result': "Proxmox API error occurred."}
+        except requests.exceptions.ConnectionError as e:
+            logging.error(f"Proxmox API ConnectionError: {e}")
+            return 500, {'result': "Failed to connect to Proxmox API."}
         except requests.exceptions.HTTPError as e:
             status = e.response.status_code
-            return 500, {'result': f"HTTP {status}: {e.response.text}"}
+            logging.error(f"Proxmox API HTTPError {status}: {e.response.text}")
+            return 500, {'result': f"Proxmox API HTTP error occurred (code {status})."}
 
 
     def migrate_lxc(self, proxmox_vmid: int, proxmox_node: str, proxmox_target_node: str):
@@ -733,11 +740,14 @@ class NetBoxProxmoxHelperMigrate(NetBoxProxmoxHelper):
             self.__wait_for_migration_task(proxmox_node, migrate_lxc_task_id)
             return 200, {'result': f"LXC (vmid: {proxmox_vmid}) has been migrated to node {proxmox_target_node}"}
         except ResourceException as e:
-            return 500, {'result': f"Proxmox API error: {e}"}
-        except requests.exceptions.ConnectionError:
-            return 500, {'result': f"Failed to connect to Proxmox API: {e}"}
+            logging.error(f"Proxmox API ResourceException: {e}")
+            return 500, {'result': "Proxmox API error occurred."}
+        except requests.exceptions.ConnectionError as e:
+            logging.error(f"Proxmox API ConnectionError: {e}")
+            return 500, {'result': "Failed to connect to Proxmox API."}
         except requests.exceptions.HTTPError as e:
             status = e.response.status_code
-            return 500, {'result': f"HTTP {status}: {e.response.text}"}
+            logging.error(f"Proxmox API HTTPError {status}: {e.response.text}")
+            return 500, {'result': f"Proxmox API HTTP error occurred (code {status})."}
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/netboxlabs/netbox-proxmox-automation/security/code-scanning/13](https://github.com/netboxlabs/netbox-proxmox-automation/security/code-scanning/13)

The best way to fix this problem is to replace all direct API responses that echo exception contents (from external libraries or internal resource/task errors) with a generic error message. Exception details should instead be logged server-side for audit and debugging purposes. The methods in `helpers/netbox_proxmox.py` that currently generate messages with `f"...{e}..."` (potentially including sensitive details) should return generic error strings (e.g. "Proxmox API error occurred") for the public API, while logging detailed exception info using `logging.error()`.

Specifically, in:
- `__wait_for_migration_task` (helpers/netbox_proxmox.py):  
  - On each exception branch (ResourceException, ConnectionError, HTTPError), replace the string that includes `{e}` or `{e.response.text}` with a generic message.
  - Add logging of the real exception for server-side review.

Similarly, for related migration and disk management helper methods, ensure all responses returned to app.py do not contain raw exception content in `result` or `content`—these fields should be sanitized.

No changes are needed within app.py outside of accepting the now sanitized response—since the code already returns jsonified dictionaries, just ensure that `results` won't include sensitive exception content.

To implement logging, import the standard Python logging module (already imported in app.py, but may need ensuring in netbox_proxmox.py).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
