### PR TITLE
Potential fix for code scanning alert no. 30: Clear-text logging of sensitive information

### DIFF
--- a/setup/helpers/netbox_proxmox_cluster.py
+++ b/setup/helpers/netbox_proxmox_cluster.py
@@ -78,7 +78,14 @@ class NetBoxProxmoxCluster(ProxmoxAPICommon):
 
         if self.debug:
             print("Proxmox nodes connection info")
-            print(json.dumps(temp_nodes_cn_info, indent=4))
+            safe_temp_nodes_cn_info = {}
+            for node_name, node_info in temp_nodes_cn_info.items():
+                safe_temp_nodes_cn_info[node_name] = dict(node_info)
+                if 'pass' in safe_temp_nodes_cn_info[node_name]:
+                    safe_temp_nodes_cn_info[node_name]['pass'] = '***REDACTED***'
+                if 'sudo_pass' in safe_temp_nodes_cn_info[node_name]:
+                    safe_temp_nodes_cn_info[node_name]['sudo_pass'] = '***REDACTED***'
+            print(json.dumps(safe_temp_nodes_cn_info, indent=4))
             print()
 
         self.proxmox_nodes_connection_info = temp_nodes_cn_info


### PR DESCRIPTION
Potential fix for [https://github.com/netboxlabs/netbox-proxmox-automation/security/code-scanning/30](https://github.com/netboxlabs/netbox-proxmox-automation/security/code-scanning/30)

To fix this without changing runtime behavior, keep collecting credentials as-is, but never print secrets directly. Specifically, in `setup/helpers/netbox_proxmox_cluster.py`, replace the debug print of `temp_nodes_cn_info` with a sanitized copy where password-like keys are redacted (e.g., `pass`, `sudo_pass`) before `json.dumps`.

Best single approach here:
- In `generate_proxmox_node_creds_configuration`, inside the `if self.debug:` block (around lines 79–82), build a `safe_temp_nodes_cn_info` dict from `temp_nodes_cn_info`.
- For each node entry, copy values and replace sensitive fields (`pass`, `sudo_pass`) with a placeholder like `"***REDACTED***"`.
- Print the sanitized dict instead of the original.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
